### PR TITLE
refactor: improve and clean up `warehouse_mgr::upsert_self_managed()`

### DIFF
--- a/src/meta/types/src/match_seq.rs
+++ b/src/meta/types/src/match_seq.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::protobuf as pb;
 use crate::seq_value::SeqV;
 use crate::ConflictSeq;
 
@@ -63,6 +64,13 @@ pub trait MatchSeqExt<T> {
 
 impl<U> MatchSeqExt<&Option<SeqV<U>>> for MatchSeq {
     fn match_seq(&self, sv: &Option<SeqV<U>>) -> Result<(), ConflictSeq> {
+        let seq = sv.as_ref().map_or(0, |sv| sv.seq);
+        self.match_seq(seq)
+    }
+}
+
+impl MatchSeqExt<&Option<pb::SeqV>> for MatchSeq {
+    fn match_seq(&self, sv: &Option<pb::SeqV>) -> Result<(), ConflictSeq> {
         let seq = sv.as_ref().map_or(0, |sv| sv.seq);
         self.match_seq(seq)
     }

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -343,6 +343,22 @@ impl pb::TxnOpResponse {
             })),
         }
     }
+
+    /// Consumes and returns the response as a `Get` response if it is one.
+    pub fn into_get(self) -> Option<pb::TxnGetResponse> {
+        match self.response {
+            Some(pb::txn_op_response::Response::Get(resp)) => Some(resp),
+            _ => None,
+        }
+    }
+
+    /// Returns the response as a `Get` response if it is one.
+    pub fn as_get(&self) -> Option<&pb::TxnGetResponse> {
+        match &self.response {
+            Some(pb::txn_op_response::Response::Get(resp)) => Some(resp),
+            _ => None,
+        }
+    }
 }
 
 impl pb::TxnGetResponse {

--- a/src/query/management/src/warehouse/warehouse_api.rs
+++ b/src/query/management/src/warehouse/warehouse_api.rs
@@ -17,17 +17,33 @@ use std::collections::HashMap;
 use databend_common_exception::Result;
 use databend_common_meta_types::NodeInfo;
 
-// Used to describe the nodes in warehouse, excluding the details of the nodes.
+/// Databend-query cluster ID.
+///
+/// A cluster is a collection of databend nodes for computation.
+pub type ClusterId = String;
+
+/// Name of a node group.
+///
+/// It is used to filter nodes in a warehouse when creating a cluster.
+pub type NodeGroupName = String;
+
+/// Specifies how to select nodes in a warehouse without exposing node details.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Eq, PartialEq, Debug)]
 pub enum SelectedNode {
-    // Randomly select a node from the tenant's list of online nodes. The selected node's group must match it if node group is specified.
-    Random(Option<String> /* node group */),
+    /// Select a random online node from the tenant's node list.
+    /// If `NodeGroupName` is specified, only nodes with this group name will be selected.
+    Random(Option<NodeGroupName>),
 }
 
-// Used to describe information about the warehouse, including both self-managed and system-managed warehouses to ensure compatibility.
+/// Contains warehouse metadata that applies to both self-managed and system-managed warehouses.
+///
+/// This enum allows uniform handling of different warehouse types while maintaining their
+/// distinct properties.
 #[derive(serde::Serialize, serde::Deserialize, Eq, PartialEq, Debug)]
 pub enum WarehouseInfo {
-    SelfManaged(String /* cluster_id of self-managed cluster */),
+    /// A warehouse managed by the tenant, i.e., the cluster id is statically configured in config file.
+    SelfManaged(ClusterId),
+    /// A warehouse managed by the system, i.e., clusters in it can be dynamically assigned and updated.
     SystemManaged(SystemManagedWarehouse),
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

### Improvements:

- Added retry mechanism with a fallback in the retry loop.
- Return an error if an unexpected response is received when `TxnGetResponse` is expected.
- Refined quit-retry condition: now only triggered when the seq of `NodeInfo` changes.

### Refactoring:

- Simplified and decoupled nested branching for better readability and maintainability.
- Consolidated related logic, e.g., building `txn if_then` operations in a single place.
- Differentiated `NodeInfo` with and without warehouse-related information.

### Documentation:
- Added details explaining behavioral differences between insert and update modes.
